### PR TITLE
feat(setter-feedback): dedupe repeated feedback requests

### DIFF
--- a/sms-insights/README.md
+++ b/sms-insights/README.md
@@ -42,6 +42,8 @@ Note: `CLAUDE_ASSISTANT_USER_ID` should point to the Slack user ID for an AI ass
 
 Also: the app will now *skip* automatic setter feedback for messages that are part of an automated `Sequence` (these are typically bulk/automated messages). Setter coaching feedback only triggers for manual outbound messages.
 
+New: setter-feedback deduping — the app now suppresses duplicate setter-feedback requests for the same message/thread for `ALOWARE_SETTER_FEEDBACK_DEDUPE_MINUTES` (default 10 minutes). Set `ALOWARE_SETTER_FEEDBACK_DEDUPE_MINUTES=0` to disable dedupe.
+
 #### Install Dependencies
 
 ```sh

--- a/sms-insights/services/setter-feedback.ts
+++ b/sms-insights/services/setter-feedback.ts
@@ -21,6 +21,26 @@ const parseBoolean = (value: string | undefined, fallback: boolean): boolean => 
   return normalized === 'true' || (normalized !== 'false' && fallback);
 };
 
+const parsePositiveInt = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return fallback;
+  return parsed;
+};
+
+// In-memory dedupe cache to prevent repeated setter-feedback posts for the same
+// thread/message. Keyed by `channelId:ts`. TTL controlled by
+// ALOWARE_SETTER_FEEDBACK_DEDUPE_MINUTES (default 10 minutes).
+const setterFeedbackCache = new Map<string, number>();
+
+export const __resetSetterFeedbackCacheForTests = (): void => {
+  setterFeedbackCache.clear();
+};
+
+const getSetterFeedbackDedupeMinutes = (): number => {
+  return parsePositiveInt(process.env.ALOWARE_SETTER_FEEDBACK_DEDUPE_MINUTES, 10);
+};
+
 const isFeedbackEnabled = (): boolean => {
   return parseBoolean(process.env.ALOWARE_SETTER_FEEDBACK_ENABLED, DEFAULT_FEEDBACK_ENABLED);
 };
@@ -119,6 +139,15 @@ export const requestSetterFeedback = async ({
   const setterName = 'Jack';
   const setterUserId = process.env.ALOWARE_WATCHER_JACK_USER_ID;
 
+  const dedupeKey = `${channelId}:${ts}`;
+  const dedupeMinutes = getSetterFeedbackDedupeMinutes();
+  const now = Date.now();
+  const lastTs = setterFeedbackCache.get(dedupeKey) || 0;
+  if (now - lastTs < dedupeMinutes * 60_000) {
+    logger.info(`Setter Feedback: suppressed duplicate request for ${dedupeKey} (within ${dedupeMinutes}m).`);
+    return;
+  }
+
   const assistants = getAssistantTargets();
   if (assistants.length === 0) return;
 
@@ -142,6 +171,8 @@ export const requestSetterFeedback = async ({
         text,
         link_names: true,
       });
+      // mark dedupe on successful post
+      setterFeedbackCache.set(dedupeKey, Date.now());
       logger.info(`Setter Feedback requested for ${setterName} from ${assistant.label} via ${source}`);
       return;
     } catch (error) {

--- a/sms-insights/tests/services/setter-feedback.test.ts
+++ b/sms-insights/tests/services/setter-feedback.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { beforeEach, describe, it, mock } from 'node:test';
 import type { WebClient } from '@slack/web-api';
-import { requestSetterFeedback } from '../../services/setter-feedback.js';
+import { requestSetterFeedback, __resetSetterFeedbackCacheForTests } from '../../services/setter-feedback.js';
 import { fakeClient, fakeLogger } from '../helpers.js';
 
 describe('setter-feedback service', () => {
@@ -32,6 +32,7 @@ describe('setter-feedback service', () => {
   });
 
   it('should post feedback for manual outbound messages (no sequence)', async () => {
+    __resetSetterFeedbackCacheForTests();
     const postSpy = mock.method((fakeClient as unknown as WebClient).chat, 'postMessage', async () => ({ ok: true }));
 
     const fields = {
@@ -50,5 +51,35 @@ describe('setter-feedback service', () => {
     assert.equal(postSpy.mock.callCount(), 1);
     const callArgs = postSpy.mock.calls[0]?.arguments[0] as { text?: string };
     assert(callArgs.text?.includes('*Setter Coaching Feedback Request*'));
+  });
+
+  it('should dedupe repeated setter-feedback requests for the same thread within TTL', async () => {
+    __resetSetterFeedbackCacheForTests();
+    process.env.ALOWARE_SETTER_FEEDBACK_ENABLED = 'true';
+    process.env.ALOWARE_SETTER_FEEDBACK_DEDUPE_MINUTES = '10';
+
+    const postSpy = mock.method((fakeClient as unknown as WebClient).chat, 'postMessage', async () => ({ ok: true }));
+
+    const fields = {
+      direction: 'outbound',
+      user: 'Jack',
+      body: 'Manual reply sent by Jack',
+      contactName: 'Taylor',
+      contactPhone: '+15552223333',
+      contactId: '1',
+      line: 'Line A',
+      sequence: '',
+    } as any;
+
+    // first call -> should post
+    await requestSetterFeedback({ client: fakeClient as unknown as WebClient, fields, logger: fakeLogger, ts: '171000.200', channelId: 'C1234' });
+    // second call within dedupe window -> should NOT post
+    await requestSetterFeedback({ client: fakeClient as unknown as WebClient, fields, logger: fakeLogger, ts: '171000.200', channelId: 'C1234' });
+
+    assert.equal(postSpy.mock.callCount(), 1);
+
+    // different thread -> should post again
+    await requestSetterFeedback({ client: fakeClient as unknown as WebClient, fields, logger: fakeLogger, ts: '171000.201', channelId: 'C1234' });
+    assert.equal(postSpy.mock.callCount(), 2);
   });
 });


### PR DESCRIPTION
Add in-memory dedupe for setter-feedback (default TTL 10 minutes) to avoid repeated coach requests on the same thread. Includes unit tests and README note.\n\nThis is a lightweight mitigation; for cross-instance dedupe we can add a DB/Redis-backed store if you want persistence across restarts.,